### PR TITLE
jdk21 compatibility

### DIFF
--- a/querydsl-codegen-utils/src/main/java/com/querydsl/codegen/utils/model/TypeExtends.java
+++ b/querydsl-codegen-utils/src/main/java/com/querydsl/codegen/utils/model/TypeExtends.java
@@ -27,7 +27,7 @@ public class TypeExtends extends TypeAdapter {
 
     public TypeExtends(String varName, Type type) {
         super(type);
-        this.varName = varName;
+        this.varName = varName.strip();
     }
 
     public TypeExtends(Type type) {

--- a/querydsl-codegen/src/main/java/com/querydsl/codegen/JavaTypeMappings.java
+++ b/querydsl-codegen/src/main/java/com/querydsl/codegen/JavaTypeMappings.java
@@ -17,6 +17,7 @@ import com.querydsl.codegen.utils.model.TypeCategory;
 import com.querydsl.core.types.Expression;
 import com.querydsl.core.types.Path;
 import com.querydsl.core.types.dsl.*;
+import com.querydsl.core.types.dsl.StringTemplate;
 
 /**
  * {@code JavaTypeMappings} defines mappings from {@link TypeCategory} instances to {@link Expression} types


### PR DESCRIPTION
Somehow JDK21's annotation processing API's Type has leading space in generic variable name which causes the querydsl codegen cannot match generic variable name with generic super type parameter.

This is quick fix that just striping leading and trailing spaces from varName.